### PR TITLE
Write to plc

### DIFF
--- a/communication_PLC/client.py
+++ b/communication_PLC/client.py
@@ -1,27 +1,47 @@
 import socket
+import time
 import os
 
-def connect_to_server(host, port, message):
-    client_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+import logging
 
-    try:
-        print(f"try connecting to {host}:{port}..")
-        client_socket.connect((host, port))
-        print("connected!")
-        print("sending..")
-        client_socket.sendall(message.encode('utf-8'))
-        print("sent.")
-        answer = client_socket.recv(1024).decode('utf-8')
-        print(f"answer from server: {answer}")
-    except Exception as e:
-        print(f"Error connecting to the server: {e}")
-    finally:
-        client_socket.close()
+# Configure logger and set its level
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.DEBUG)
+formatter = logging.Formatter('%(asctime)s:%(levelname)s:%(name)s:%(lineno)d:%(message)s')
+# Set log file, its level and format
+file_handler = logging.FileHandler('./remote_control_logger.log')
+file_handler.setLevel(logging.INFO)
+file_handler.setFormatter(formatter)
+# Set stream its level and format
+stream_handler = logging.StreamHandler()
+stream_handler.setFormatter(formatter)
+logger.addHandler(file_handler)
+logger.addHandler(stream_handler)
 
+# Start handling connection
 
-if __name__ == "__main__":
+server_host = os.environ.get('Server_ip_navgreen_control')
+server_port = int(os.environ.get('Server_port_navgreen_control'))
 
-    server_host = os.environ.get('Server_ip_navgreen_control')
-    server_port = int(os.environ.get('Server_port_navgreen_control'))
+try:
+    while True:
 
-    connect_to_server(server_host, server_port, "Hello, server!")
+        # time.sleep(5*60)
+        time.sleep(10)
+
+        try:
+            client_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+
+            client_socket.connect((server_host, server_port))
+            logger.info(f"Connected to {server_host}:{server_port}.")
+
+            setpoint_DHW = float(client_socket.recv(1024).decode('utf-8'))
+            logger.info(f"Setpoint from server: {setpoint_DHW}.")
+
+            client_socket.close()
+
+        except Exception as e:
+            logger.error(f"Error connecting to the server: {e}")
+
+except KeyboardInterrupt:
+    logger.info("Client ends process.")

--- a/communication_PLC/client.py
+++ b/communication_PLC/client.py
@@ -64,7 +64,7 @@ if __name__ == "__main__":
     reconnect_interval = 30  # Seconds
 
     too_cold = False
-    min_setpoint, max_setpoint = 15.0, 51.0
+    min_setpoint, max_setpoint = 15.0, 49.0
 
     try:
         while True:
@@ -136,7 +136,7 @@ if __name__ == "__main__":
                                     # If heat pump is on
                                     if compressor_HZ >= 30.0 and POWER_HP > 2.0:
                                         # Top of tank is too hot
-                                        if DHW_buffer > 52.0:
+                                        if DHW_buffer > 50.0:
                                             # Turn of HP
                                             new_DHW_setpoint = min_setpoint
 

--- a/communication_PLC/client.py
+++ b/communication_PLC/client.py
@@ -122,7 +122,7 @@ if __name__ == "__main__":
                             DHW_buffer = read_reg_value(result, 10, 10)
                             POWER_HP = read_reg_value(result, 19, 1000)
                             compressor_HZ = read_reg_value(other_registers, 24, 10)
-                            T_setpoint_DHW_modbus = read_reg_value(setpoint_registers, 1, 10)
+                            # T_setpoint_DHW_modbus = read_reg_value(setpoint_registers, 1, 10)
 
                             # Setpoint value given by the server
                             new_DHW_setpoint = setpoint_DHW
@@ -145,7 +145,7 @@ if __name__ == "__main__":
                                             too_cold = True
                                             new_DHW_setpoint = min_setpoint
 
-                                    # Everything written regardless whether hp is on?????
+                                    # Everything written regardless whether hp is on
                                     write_reg_value(modbus_client, 541, new_DHW_setpoint, 10)
                                 else:
                                     # If hp was closed due to cold temperature, should wait until it is at least 12

--- a/communication_PLC/client.py
+++ b/communication_PLC/client.py
@@ -37,8 +37,16 @@ def read_reg_value(register, index, divisor):
 
 
 def write_reg_value(client, register, value, multiplier):
+    """
+    Change the value of some registers.
+    :param client: ModBus client
+    :param register: Register to change
+    :param value: New value (semantic)
+    :param multiplier: Multiplier to make semantic value integer
+    :return: None
+    """
     # Convert float to integer
-    new_value = value * multiplier
+    new_value = int(value * multiplier)
     client.write_coil(register, new_value)
 
     return

--- a/communication_PLC/client.py
+++ b/communication_PLC/client.py
@@ -1,0 +1,27 @@
+import socket
+import os
+
+def connect_to_server(host, port, message):
+    client_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+
+    try:
+        print(f"try connecting to {host}:{port}..")
+        client_socket.connect((host, port))
+        print("connected!")
+        print("sending..")
+        client_socket.sendall(message.encode('utf-8'))
+        print("sent.")
+        answer = client_socket.recv(1024).decode('utf-8')
+        print(f"answer from server: {answer}")
+    except Exception as e:
+        print(f"Error connecting to the server: {e}")
+    finally:
+        client_socket.close()
+
+
+if __name__ == "__main__":
+
+    server_host = os.environ.get('Server_ip_navgreen_control')
+    server_port = int(os.environ.get('Server_port_navgreen_control'))
+
+    connect_to_server(server_host, server_port, "Hello, server!")

--- a/communication_PLC/client.py
+++ b/communication_PLC/client.py
@@ -1,6 +1,9 @@
 import socket
 import time
 import os
+import struct
+
+from pymodbus.client import ModbusTcpClient
 
 import logging
 
@@ -18,30 +21,195 @@ stream_handler.setFormatter(formatter)
 logger.addHandler(file_handler)
 logger.addHandler(stream_handler)
 
-# Start handling connection
 
-server_host = os.environ.get('Server_ip_navgreen_control')
-server_port = int(os.environ.get('Server_port_navgreen_control'))
+def read_reg_value(register, index, divisor):
+    """
+    This function reads the correct value from the PLC, translates it
+    to a signed integer and then converts it to the correct decimal unit
+    :param register: Register to read values from
+    :param index: Register's index
+    :param divisor: Value's divisor to convert to preferred unit
+    :return: Value converted to signed int
+    """
+    value = register.registers[index]
+    value = struct.unpack('>h', struct.pack('>H', value))[0]
+    return value / divisor
 
-try:
-    while True:
 
-        # time.sleep(5*60)
-        time.sleep(10)
+# def read_reg_value(register, index, multiplier):
 
-        try:
-            client_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
 
-            client_socket.connect((server_host, server_port))
-            logger.info(f"Connected to {server_host}:{server_port}.")
+if __name__ == "__main__":
 
-            setpoint_DHW = float(client_socket.recv(1024).decode('utf-8'))
-            logger.info(f"Setpoint from server: {setpoint_DHW}.")
+    # IP and port of server for communication
+    server_host = os.environ.get('Server_ip_navgreen_control')
+    server_port = int(os.environ.get('Server_port_navgreen_control'))
 
-            client_socket.close()
+    # PLC IP address, port and connection intervals
+    plc_ip = os.environ.get('Plc_ip')
+    plc_port = 502
+    reconnect_interval = 30  # Seconds
 
-        except Exception as e:
-            logger.error(f"Error connecting to the server: {e}")
+    try:
+        while True:
+            # Try to connect with the server to get the new DHW - setpoint value
+            try:
+                client_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
 
-except KeyboardInterrupt:
-    logger.info("Client ends process.")
+                client_socket.connect((server_host, server_port))
+                logger.info(f"Connected to {server_host}:{server_port}.")
+
+                setpoint_DHW = float(client_socket.recv(1024).decode('utf-8'))
+                logger.info(f"Setpoint from server: {setpoint_DHW}.")
+
+                client_socket.close()
+
+                # Now, write the new setpoint to the PLC
+                # Connect with the PLC
+                modbus_client = None
+
+                # This try-except is to catch a ctrl-c
+                try:
+
+                    while True:
+                        print("still here")
+
+                        try:
+                            # Create a Modbus TCP/IP modbus_client
+                            modbus_client = ModbusTcpClient(plc_ip, port=plc_port)
+                            modbus_client.connect()
+
+                            logger.info("Acquire and write data.")
+
+                            # Read holding register D500, D501, D502
+                            result_coils2 = modbus_client.read_coils(8192 + 509, 7, int=0)  # read coils from 509 to 515
+                            result_coils = modbus_client.read_coils(8192 + 500, 4)  # Read coils from 500 to 503
+
+                            result = modbus_client.read_holding_registers(500, 20)  # Read registers from 500 to 519
+                            results_registers2 = modbus_client.read_holding_registers(520, 18)  # Read registers from 520 to 527
+                            setpoint_registers = modbus_client.read_holding_registers(540, 2)  # Read holding registers 540 and 541, setpoint SH and setpoint DHW
+
+                            other_registers = modbus_client.read_holding_registers(542, 25)  # Read remaining pressure and temp registers
+
+                            # READ COILS FROM PLC
+                            Air_source_valve = result_coils.bits[0]
+                            BTES_source_valve = result_coils.bits[1]
+                            PVT_setting_valve = result_coils.bits[2]
+                            Condenser_three_way = result_coils.bits[3]
+
+                            # READ COILS AGAIN
+                            Residential_office = result_coils2.bits[0]
+                            BTES_HEATING_DHW_THREE_WAY = result_coils2.bits[1]
+                            BTES_GROUND_SOLAR_VALVE = result_coils2.bits[2]
+                            BTES_SOLAR_THREE_WAY_VALVE = result_coils2.bits[3]
+                            BTES_WATER_AIR_OPERATION = result_coils2.bits[4]
+                            HEATING_COOLING_MODE = result_coils2.bits[5]
+                            BMES_LOCAL_CONTROL = result_coils2.bits[6]
+
+                            # READ PLC REGISTERS
+                            T_cond_out = read_reg_value(result, 0, 10)
+                            T_cond_in = read_reg_value(result, 1, 10)
+                            flow_condenser = read_reg_value(result, 2, 10000)
+                            T_evap_out = read_reg_value(result, 3, 10)
+                            T_evap_in = read_reg_value(result, 4, 10)
+                            flow_evap = read_reg_value(result, 5, 10000)
+                            T_air_source = read_reg_value(result, 6, 10)
+                            T_BTES_source = read_reg_value(result, 7, 10)
+                            T_solar_buffer_source = read_reg_value(result, 8, 10)
+                            T_space_heating_buffer = read_reg_value(result, 9, 10)
+                            T_DHW_buffer = read_reg_value(result, 10, 10)
+                            T_indoor_temp = read_reg_value(result, 11, 10)
+                            T_dhw_out = read_reg_value(result, 12, 10)
+                            T_dhw_in = read_reg_value(result, 13, 10)
+                            flow_dhw = read_reg_value(result, 14, 10000)
+                            T_hp_out_sh_in = read_reg_value(result, 15, 10)
+                            T_sh_out_hp_in = read_reg_value(result, 16, 10)
+                            T_hp_out_to_dhw_tank = read_reg_value(result, 17, 10)
+                            T_hp_in_from_dhw_tank = read_reg_value(result, 18, 10)
+                            Total_electric_power = read_reg_value(result, 19, 1000)
+
+                            # READ HOLDING REGISTERS AGAIN
+                            T_from_sh_to_demand = read_reg_value(results_registers2, 0, 10)
+                            T_from_demand_to_space_bufer = read_reg_value(results_registers2, 1, 10)
+                            flow_water_demand = read_reg_value(results_registers2, 2, 10000)
+                            Power_PV = read_reg_value(results_registers2, 3, 10000)
+                            Solar_irr_tilted = read_reg_value(results_registers2, 4, 10000)
+                            T_pvt_in = read_reg_value(results_registers2, 5, 10)
+                            T_pvt_out = read_reg_value(results_registers2, 6, 10)
+                            T_pvt_in_to_dhw = read_reg_value(results_registers2, 7, 10)
+                            T_dhw_out_to_pvt = read_reg_value(results_registers2, 8, 10)
+                            T_pvt_in_to_solar_buffer = read_reg_value(results_registers2, 9, 10)
+                            T_solar_buffer_out_to_pvt = read_reg_value(results_registers2, 10, 10)
+                            flow_solar_circuit = read_reg_value(results_registers2, 11, 10000)
+                            T_hp_out_to_solar_buffer_in = read_reg_value(results_registers2, 12, 10)
+                            T_hp_in_from_solar_buffer = read_reg_value(results_registers2, 13, 10)
+                            T_hp_out_to_btes_in = read_reg_value(results_registers2, 14, 10)
+                            T_BTES_out_to_hp_in = read_reg_value(results_registers2, 15, 10)
+
+                            # READ REMAINING PRESSURES AND TEMP
+                            T_cond_out_ref = read_reg_value(other_registers, 0, 10)
+                            T_evap_out_ref = read_reg_value(other_registers, 1, 10)
+                            T_cond_in_ref = read_reg_value(other_registers, 2, 10)
+                            T_receiv_in_liq_ref = read_reg_value(other_registers, 3, 10)
+                            T_receiv_out_liq_ref = read_reg_value(other_registers, 4, 10)
+                            T_eco_liq_out_ref = read_reg_value(other_registers, 5, 10)
+                            T_suction_ref = read_reg_value(other_registers, 6, 10)
+                            T_discharge_ref = read_reg_value(other_registers, 7, 10)
+                            T_eco_vap_ref = read_reg_value(other_registers, 8, 10)
+                            T_expansion_ref = read_reg_value(other_registers, 9, 10)
+                            T_eco_expansion_ref = read_reg_value(other_registers, 10, 10)
+
+                            P_suction = read_reg_value(other_registers, 18, 10)
+                            P_discharge = read_reg_value(other_registers, 19, 10)
+                            P_eco = read_reg_value(other_registers, 20, 10)
+
+                            eev_main_percentage = read_reg_value(other_registers, 21, 10)
+                            eev_eco_percentage = read_reg_value(other_registers, 22, 10)
+
+                            T_dhw_bottom = read_reg_value(other_registers, 23, 10)
+
+                            compressor_HZ = read_reg_value(other_registers, 24, 10)
+
+                            # READ SET-POINTS
+                            T_setpoint_DHW_modbus = read_reg_value(setpoint_registers, 1, 10)
+                            T_setpoint_SPACE_HEATING_modbus = read_reg_value(setpoint_registers, 0, 10)
+
+                            ############################################
+                            # Write when conditions are met:
+
+                            # - If heat pump is on and temperature of DHW tank (top layer) > 52 oC, hp must be turned off
+                            # - If temp of the gorund (BTES tank) < 8 oC, hp must be turned off AND turned back on IF themp of ground tank is above 12 oC
+
+                            # write(num_of_register, value)
+                            # CONVERT IT TO INTEGER !!
+                            # client_modbus.write_coil(8192 + 126, True)
+
+                            ############################################
+
+                            # PLC must write no sooner than 5 minutes
+                            time.sleep(10)
+                            # time.sleep(5*60)
+
+                            break
+
+                        # PLC exception raised
+                        except Exception as e:
+                            logger.error(f"{e}")
+                            logger.info(f"Sleeping for {reconnect_interval} seconds..")
+                            time.sleep(reconnect_interval)
+                            continue
+
+                # Close connection when interrupted by the user
+                except KeyboardInterrupt:
+                    if modbus_client is not None and modbus_client.is_socket_open():
+                        modbus_client.close()
+                        logger.info("Closed PLC socket.")
+
+            except Exception as e:
+                logger.error(f"{e}")
+                logger.info(f"Sleeping for {reconnect_interval} seconds..")
+                time.sleep(reconnect_interval)
+
+
+    except KeyboardInterrupt:
+        logger.info("Client ends process.")

--- a/communication_PLC/server.py
+++ b/communication_PLC/server.py
@@ -1,0 +1,35 @@
+import socket
+import os
+
+def start_listening(host, port):
+    server_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    server_socket.bind((host, port))
+
+    server_socket.listen(1)
+    print('Server listening on ' + str(host) + ':' + str(port))
+
+    try:
+        while True:
+            client_socket, client_address = server_socket.accept()
+            print('Connection established with' + str(client_address))
+
+            data = client_socket.recv(1024)
+            print('Received message:' + str(data.decode('utf-8')))
+
+            answer = "ok mate"
+            client_socket.send(answer.encode('utf-8'))
+
+            client_socket.close()
+
+            print('closing connection with ' + str(client_address))
+
+    except KeyboardInterrupt:
+        print("Bye from the server")
+
+if __name__ == "__main__":
+
+    server_host = os.environ.get('Server_ip_navgreen_control')
+    server_port = int(os.environ.get('Server_port_navgreen_control'))
+
+    start_listening(server_host, server_port)
+

--- a/communication_PLC/server.py
+++ b/communication_PLC/server.py
@@ -14,17 +14,38 @@ server_socket.listen(1)
 print('Server listening on ' + str(server_host) + ':' + str(server_port))
 
 try:
+    # Incoming connection
+    client_socket, client_address = server_socket.accept()
+    print('Connection established with' + str(client_address))
+
+    # Client sents the range of the acceptable setpoint values
+    setpoint_range = client_socket.recv(1024).decode('utf-8')
+    print('Setpoint range: ' + str(setpoint_range))
+
+    # Get the range in floats
+    setpoint_range = setpoint_range.split("-")
+    setpoint_min, setpoint_max = float(setpoint_range[0]), float(setpoint_range[1])
+
     setpoint_DHW = None
     confirmation = None
+    valid_range = False
 
-    while confirmation != "y":
+    while confirmation != "y" or not valid_range:
         setpoint_DHW = input("Please enter the desired value: ")
 
         try:
             # Only accept numerical values
             setpoint_DHW = float(setpoint_DHW)
 
+            # If setpoint is not within accepted range
+            if setpoint_DHW < setpoint_min or setpoint_DHW > setpoint_max:
+                print("Invalid input. Please enter a setpoint within: ["+ str(setpoint_min) +", " + str(setpoint_max) +  "].")
+                continue
+            else:
+                valid_range = True
+
             while True:
+
                 confirmation = input("Is the entered value the new DHW setpoint? (y/n): ").lower()
 
                 if confirmation == "y":
@@ -40,22 +61,18 @@ try:
             print("Invalid input. Please enter a number.")
             continue
 
-         # Incoming connection
-        client_socket, client_address = server_socket.accept()
-        print('Connection established with' + str(client_address))
+    try:
+        # If is number and user is sure about their choices, send setpoint to client
+        client_socket.send(str(setpoint_DHW).encode('utf-8'))
+        print("Setpoint sent.")
 
-        try:
-            # If is number and user is sure about their choices, send setpoint to client
-            client_socket.send(str(setpoint_DHW).encode('utf-8'))
-            print("Setpoint sent.")
+    except Exception as e:
+        print("\nSending the setpoint failed: " + str(e))
 
-        except Exception as e:
-            print("\nSending the setpoint failed: " + str(e))
-
-        finally:
-            # Terminate connection
-            client_socket.close()
-            print('Closing connection with ' + str(client_address))
+    finally:
+        # Terminate connection
+        client_socket.close()
+        print('Closing connection with ' + str(client_address))
 
 except KeyboardInterrupt:
     # User performed Ctrl ^C

--- a/communication_PLC/server.py
+++ b/communication_PLC/server.py
@@ -14,47 +14,48 @@ server_socket.listen(1)
 print('Server listening on ' + str(server_host) + ':' + str(server_port))
 
 try:
-    while True:
+    setpoint_DHW = None
+    confirmation = None
 
-        # Incoming connection
+    while confirmation != "y":
+        setpoint_DHW = input("Please enter the desired value: ")
+
+        try:
+            # Only accept numerical values
+            setpoint_DHW = float(setpoint_DHW)
+
+            while True:
+                confirmation = input("Is the entered value the new DHW setpoint? (y/n): ").lower()
+
+                if confirmation == "y":
+                    print("Sending the value to the PLC when it connects.")
+                    break
+                elif confirmation == "n":
+                    print("Re-enter DHW setpoint.")
+                    break
+                else:
+                    print("Invalid input. Please enter 'y' or 'n'.")
+
+        except ValueError:
+            print("Invalid input. Please enter a number.")
+            continue
+
+         # Incoming connection
         client_socket, client_address = server_socket.accept()
         print('Connection established with' + str(client_address))
 
-        setpoint_DHW = None
-        confirmation = None
+        try:
+            # If is number and user is sure about their choices, send setpoint to client
+            client_socket.send(str(setpoint_DHW).encode('utf-8'))
+            print("Setpoint sent.")
 
-        # Get the setpoint from the user - only check for numerical value.
-        # The PLC-related checks will be conducted from the client process
+        except Exception as e:
+            print("\nSending the setpoint failed: " + str(e))
 
-        while confirmation != "y":
-            setpoint_DHW = input("Please enter the desired value: ")
-
-            try:
-                # Only accept numerical values
-                setpoint_DHW = float(setpoint_DHW)
-
-                while True:
-                    confirmation = input("Is the entered value the new DHW setpoint? (y/n): ").lower()
-
-                    if confirmation == "y":
-                        print("Sending the value to the PLC.")
-                        break
-                    elif confirmation == "n":
-                        print("Re-enter DHW setpoint.")
-                        break
-                    else:
-                        print("Invalid input. Please enter 'y' or 'n'.")
-
-            except ValueError:
-                print("Invalid input. Please enter a number.")
-                continue
-
-        # If is number and user is sure about their choices, send setpoint to client
-        client_socket.send(str(setpoint_DHW).encode('utf-8'))
-
-        # Terminate connection
-        client_socket.close()
-        print('Closing connection with ' + str(client_address))
+        finally:
+            # Terminate connection
+            client_socket.close()
+            print('Closing connection with ' + str(client_address))
 
 except KeyboardInterrupt:
     # User performed Ctrl ^C

--- a/communication_PLC/server.py
+++ b/communication_PLC/server.py
@@ -20,10 +20,6 @@ try:
         client_socket, client_address = server_socket.accept()
         print('Connection established with' + str(client_address))
 
-        # Receive the invitation
-        data = client_socket.recv(1024)
-        print('Received message:' + str(data.decode('utf-8')))
-
         setpoint_DHW = None
         confirmation = None
 

--- a/live_data_analysis/data_and_connection.py
+++ b/live_data_analysis/data_and_connection.py
@@ -212,7 +212,7 @@ if __name__ == "__main__":
                                "WATER_OUT_COND": T_cond_out,
                                "SH1_IN": T_hp_out_sh_in,
                                "SH1_RETURN": T_sh_out_hp_in,
-                               "DIFFUSE_SOLAR_IRR": np.nan,
+                               "AIR_HP_TO_BTES_TANK": np.nan,
                                "DHW_INLET": T_dhw_in,
                                "DHW_OUTLET": T_dhw_out,
                                "DHW_BOTTOM": T_dhw_bottom,

--- a/navgreen_base/__init__.py
+++ b/navgreen_base/__init__.py
@@ -1,2 +1,2 @@
 from navgreen_base.influx import write_data, read_data, delete_data, establish_influxdb_connection, set_bucket
-from navgreen_base.processing import columns, flow, power, solar, temp_sensors, other, pressure, control, checkpoints, process_data, value_limits
+from navgreen_base.processing import columns, flow, power, solar, solar_diff_source, temp_sensors, other, pressure, control, checkpoints, process_data, value_limits

--- a/navgreen_base/influx.py
+++ b/navgreen_base/influx.py
@@ -46,8 +46,8 @@ def make_point(measurement, row, value_columns, tag_columns):
         try:
             if row[col] is not np.nan:
                 p.field(col, row[col])
-        except KeyError:  # Checkpoints and DIFFUSE_SOLAR_IRR are not always stored e.g. historical data or if they have not changed
-            if col not in checkpoints and col != "DIFFUSE_SOLAR_IRR":
+        except KeyError:  # Checkpoints are not always stored e.g. historical data or if they have not changed
+            if col not in checkpoints:
                 logger.critical(f"Cannot find column {col}.")
                 sys.exit(1)
 

--- a/navgreen_base/processing.py
+++ b/navgreen_base/processing.py
@@ -34,7 +34,7 @@ flow = ["FLOW_EVAPORATOR", "FLOW_CONDENSER", "FLOW_DHW", "FLOW_SOLAR_HEAT_REJECT
 
 power = ["POWER_HP", "POWER_PVT"]
 
-solar = ["PYRANOMETER", "DIFFUSE_SOLAR_IRR"]
+solar = ["PYRANOMETER"]
 
 other = ["Compressor_HZ", "EEV_LOAD1", "EEV_LOAD2"]
 
@@ -101,18 +101,16 @@ def process_data(df, hist_data=True):
                          "SOLAR_BUFFER_IN", "SOLAR_BUFFER_OUT", "BTES_TANK_IN", "BTES_TANK_OUT", "DHW_BOTTOM",
                          "RECEIVER_LIQUID_IN", "RECEIVER_LIQUID_OUT", "ECO_LIQUID_OUT", "SUCTION_TEMP", "DISCHARGE_TEMP",
                          "ECO_VAPOR_TEMP", "EXPANSION_TEMP", "ECO_EXPANSION_TEMP", "SUCTION_PRESSURE",
-                         "DISCHARGE_PRESSURE", "ECO_PRESSURE", "DIFFUSE_SOLAR_IRR"]
+                         "DISCHARGE_PRESSURE", "ECO_PRESSURE"]
 
         columns_div1000 = ["POWER_HP"]
 
         columns_div10000 = ["FLOW_CONDENSER", "FLOW_EVAPORATOR", "FLOW_DHW", "FLOW_FAN_COILS_INDOOR", "POWER_PVT",
                             "PYRANOMETER", "FLOW_PVT"]
 
-        '''
         # Measurements we do not read from the PLC yet
-        columns_nan = ["SOLAR_HEAT_REJECTION_IN", "SOLAR_HEAT_REJECTION_OUT", "FLOW_SOLAR_HEAT_REJECTION"]
+        # columns_nan = ["SOLAR_HEAT_REJECTION_IN", "SOLAR_HEAT_REJECTION_OUT", "AIR_HP_TO_BTES_TANK", "FLOW_SOLAR_HEAT_REJECTION"]
 
-        '''
         for col in columns_div10:
             df[col] = df[col] / 10
 
@@ -127,7 +125,7 @@ def process_data(df, hist_data=True):
             df[col] = np.nan
         '''
 
-        df["DATETIME"] = pd.to_datetime(df['DATETIME'], format="%Y-%m-%d %H:%M:%S")
+        df['DATETIME'] = pd.to_datetime(df['DATETIME'], utc=True)
 
     # Apply reasonable limits
     for col in solar:

--- a/testcases/test_preprocessing.py
+++ b/testcases/test_preprocessing.py
@@ -31,7 +31,7 @@ class TestPreproc( unittest.TestCase ):
         cls.test_data_path = "./testcases/sample_data/"
         cls._sample_input = pd.read_csv( cls.test_data_path+"sample_input.csv" )
         # Apply transformation
-        cls._sample_input = process_data(cls._sample_input, hist_data=False)
+        cls._sample_input = process_data(cls._sample_input, hist_data=True)
 
         # Wipe clean the test bucket
         logger.info( f"Emptying {bucket}... ")


### PR DESCRIPTION
This PR, if merged, closes Issue #30 by implementing a client-server service, where the computer in the PLC installation (that poses as the client process)  tries  every 5 minutes to connect to the server process (a process run in a vm whenever we want) and if it succeeds, it expects a new setpoint value that will possibly be written to the PLC.

The server process makes sure that the setpoint value is numerical and within range, whereas the client process -before writing the checkpoint- checks all the domain specific constraints, so that we do not write gibberish to the PLC and it goes kaboom.

The processes have been tested making sure they,
- Handle connection exceptions (internet, PLC)
- Handle user's commands (Ctrl^C's) and errored value typings
- Adhere to the domain specific constraints
- Do the job they are supposed to do